### PR TITLE
fix: Prevent wallet operations before PIN validation

### DIFF
--- a/src/components/NavMenu/NavMenu.tsx
+++ b/src/components/NavMenu/NavMenu.tsx
@@ -53,7 +53,7 @@ const NavMenu: Component< { id?: string } > = (props) => {
       label: 'Wallet',
       icon: 'walletIcon',
       bubble: () => !sparkWallet?.store.isConfigured ? 1 : 0,
-      hidden: () => !sparkWallet?.store.isEnabled,
+      hidden: () => !sparkWallet?.store.isEnabled || (account?.showPin || '').length > 0,
     },
     {
       to: '/bookmarks',

--- a/src/lib/PrimalNostr.ts
+++ b/src/lib/PrimalNostr.ts
@@ -84,7 +84,14 @@ export const PrimalNostr: (pk?: string) => NostrExtension = (pk?: string) => {
     let sec: string = pk || readSecFromStorage() || tempNsec() || generateNsec();
 
     if (sec.startsWith(pinEncodePrefix)) {
-      sec = await decryptWithPin(currentPin(), sec);
+      const pin = currentPin();
+
+      // Check if PIN is required but not yet provided
+      if (!pin || pin.length === 0) {
+        throw('pin-required');
+      }
+
+      sec = await decryptWithPin(pin, sec);
     }
 
     const decoded = nip19.decode(sec);

--- a/src/pages/WalletNew.tsx
+++ b/src/pages/WalletNew.tsx
@@ -857,19 +857,41 @@ const WalletContent: Component = () => {
   };
 
   return (
-    <div class={styles.walletPage}>
-      {/* Lightning flash animation for incoming payments */}
-      <Show when={showPaymentFlash()}>
-        <LightningFlash duration={1000} active={showPaymentFlash()} />
-      </Show>
+    <Show
+      when={(account?.showPin || '').length === 0}
+      fallback={
+        <div class={styles.walletPage}>
+          <PageTitle title="Lightning Wallet" />
+          <PageCaption>
+            <div>Breez Spark Wallet</div>
+          </PageCaption>
+          <div class={styles.walletContent}>
+            <div class={styles.walletEmpty}>
+              <Loader />
+              <div class={styles.emptyTitle}>
+                PIN Required
+              </div>
+              <div class={styles.emptyMessage}>
+                Please enter your PIN to access the wallet
+              </div>
+            </div>
+          </div>
+        </div>
+      }
+    >
+      <div class={styles.walletPage}>
+        {/* Lightning flash animation for incoming payments */}
+        <Show when={showPaymentFlash()}>
+          <LightningFlash duration={1000} active={showPaymentFlash()} />
+        </Show>
 
-      <PageTitle title="Lightning Wallet" />
+        <PageTitle title="Lightning Wallet" />
 
-      <PageCaption>
-        <div>Breez Spark Wallet</div>
-      </PageCaption>
+        <PageCaption>
+          <div>Breez Spark Wallet</div>
+        </PageCaption>
 
-      <div class={styles.walletContent}>
+        <div class={styles.walletContent}>
         <Show
           when={sparkWallet.store.isConnected || (sparkWallet.store.isConfigured && sparkWallet.store.balance > 0)}
           fallback={
@@ -1670,7 +1692,8 @@ const WalletContent: Component = () => {
           </Show>
         </div>
       </AdvancedSearchDialog>
-    </div>
+      </div>
+    </Show>
   );
 };
 


### PR DESCRIPTION
  - Add PIN validation check in getSec() before attempting decryption
  - Hide wallet navigation until PIN is validated
  - Show PIN Required screen if wallet accessed before PIN entry
  - Prevents "Wrong string length: 0" errors on page refresh
  - Fixes #1

  Files changed:
  - src/lib/PrimalNostr.ts: Add pin-required error check
  - src/components/NavMenu/NavMenu.tsx: Hide wallet nav when PIN needed
  - src/pages/WalletNew.tsx: Guard wallet page with PIN check