### PR TITLE
fix: add BIP39 mnemonic validation before wallet operations

### DIFF
--- a/src/pages/WalletNew.tsx
+++ b/src/pages/WalletNew.tsx
@@ -15,7 +15,7 @@ import CurrencyDropdown from '../components/CurrencyDropdown/CurrencyDropdown';
 import LightningAddressCard from '../components/LightningAddressCard/LightningAddressCard';
 import LightningFlash from '../components/LightningFlash/LightningFlash';
 import Loader from '../components/Loader/Loader';
-import { generateMnemonic } from '@scure/bip39';
+import { generateMnemonic, validateMnemonic } from '@scure/bip39';
 import { wordlist } from '@scure/bip39/wordlists/english.js';
 import { useCurrencyConversion } from '../hooks/useCurrencyConversion';
 import { formatFiatAmount } from '../lib/currency';
@@ -120,6 +120,11 @@ const WalletContent: Component = () => {
 
     if (!seed) {
       toast?.sendWarning('Please enter a mnemonic');
+      return;
+    }
+
+   if (!validateMnemonic(seed, wordlist)) {
+      toast?.sendWarning('Invalid seed phrase. Please check your 12-word recovery phrase.');
       return;
     }
 
@@ -251,7 +256,12 @@ const WalletContent: Component = () => {
       toast?.sendWarning('Please enter a mnemonic');
       return;
     }
-
+    
+    if (!validateMnemonic(seed, wordlist)) {
+      toast?.sendWarning('Invalid seed phrase. Please check your 12-word recovery phrase.');
+      return;
+    }
+    
     if (!account?.publicKey) {
       toast?.sendWarning('Please log in first');
       return;


### PR DESCRIPTION
## Summary
Adds BIP39 mnemonic validation before wallet creation and restoration to prevent cryptic errors from invalid seed phrases.

## Problem
Currently, users can enter invalid mnemonics (wrong words, wrong word count, gibberish) when restoring a wallet. The app accepts these and attempts to connect, resulting in cryptic Breez SDK errors that confuse users.

Example invalid inputs that are currently accepted:
- Random words not in BIP39 wordlist
- Incorrect word count (not 12 or 24 words)
- Complete gibberish like "hello world test fake"

## Solution
- Import `validateMnemonic` from `@scure/bip39` 
- Add validation in `handleCreateWallet()` before creating wallet
- Add validation in `handleRestoreFromManual()` before restoring wallet
- Show clear error message: "Invalid seed phrase. Please check your 12-word recovery phrase."

## Testing
- Tested with invalid mnemonic - shows error message
- Tested with valid mnemonic - wallet creates/restores successfully
- No functional changes to valid wallet operations

## Impact
Improves UX by catching invalid seed phrases early with clear error messages instead of cryptic SDK failures.