### PR TITLE
fix: validate and clamp top-up amount input to valid range

### DIFF
--- a/src/pages/WalletNew.tsx
+++ b/src/pages/WalletNew.tsx
@@ -406,12 +406,17 @@ const WalletContent: Component = () => {
     setTopUpAmount(amount);
   };
 
-  const handleTopUpInputChange = (value: string) => {
+const handleTopUpInputChange = (value: string) => {
     const numValue = parseInt(value) || 0;
-    setTopUpAmount(numValue);
+    
+    // Clamp to valid range (minimum 1000 sats, maximum based on wallet limit)
+    const clampedValue = Math.max(1000, Math.min(numValue, maxTopUpAmount()));
+    
+    setTopUpAmount(clampedValue);
+    
     // Select preset if it matches, otherwise clear
-    const matchingPreset = topUpPresets.find(p => p.amount === numValue);
-    setSelectedPreset(matchingPreset ? numValue : null);
+    const matchingPreset = topUpPresets.find(p => p.amount === clampedValue);
+    setSelectedPreset(matchingPreset ? clampedValue : null);
   };
 
   const generateQRCode = async (invoice: string) => {


### PR DESCRIPTION
- Add input validation in handleTopUpInputChange
- Clamp values to minimum 1000 sats (matching UI min attribute)
- Clamp values to maximum based on wallet balance limit
- Prevents negative amounts from being set
- Prevents values below minimum threshold (e.g., 1, 500, 999)
- HTML min attribute alone doesn't prevent programmatic invalid values

Tested:
- Negative values ( copy/paste -5000, because negative numbers weren't accepted ) → clamped to 1000 
- Zero (0) → clamped to 1000 
- Below minimum (500) → clamped to 1000 
- Valid amounts (25000) → accepted 